### PR TITLE
fix for visualization of surface corners behind the camera

### DIFF
--- a/src/surface_tracker/location.py
+++ b/src/surface_tracker/location.py
@@ -289,13 +289,24 @@ class SurfaceLocation(abc.ABC):
 
         shape = points.shape
         points.shape = (-1, 1, 2)
-        points = cv2.perspectiveTransform(points, transform_matrix)
+        points = _perspective_transform(points, transform_matrix)
         points.shape = shape
 
         return points
 
 
 ##### Helper functions
+
+
+def _perspective_transform(points, transform_matrix):
+    homogeneous_points = cv2.convertPointsToHomogeneous(points)
+    res = []
+    for p in homogeneous_points:
+        projected_point = np.dot(transform_matrix, p[0])
+        projected_point[2] = abs(projected_point[2])  # flip points with negative z
+        res.append(projected_point)
+
+    return cv2.convertPointsFromHomogeneous(np.asarray(res))
 
 
 def _find_homographies(points_A, points_B):

--- a/src/surface_tracker/location.py
+++ b/src/surface_tracker/location.py
@@ -327,8 +327,7 @@ def project_points_pos_z(homogeneous_points, transform_matrix):
     for p in homogeneous_points:
         projected_point = np.dot(transform_matrix, p[0])
         if projected_point[2] < 0:
-            projected_point[2] = min(
-                abs(projected_point[2]),
+            projected_point[2] = (
                 np.linalg.norm([projected_point[0], projected_point[1]]) / 32,
             )
         res.append(projected_point)

--- a/src/surface_tracker/location.py
+++ b/src/surface_tracker/location.py
@@ -308,7 +308,7 @@ def is_clockwise_triangle(points):
     val = (float(p2[1] - p1[1]) * (p3[0] - p2[0])) - (
         float(p2[0] - p1[0]) * (p3[1] - p2[1])
     )
-    return val < 0
+    return val > 0
 
 
 def orientation_quadrupel(points, clockwise=True):

--- a/src/surface_tracker/location.py
+++ b/src/surface_tracker/location.py
@@ -161,6 +161,7 @@ class SurfaceLocation(abc.ABC):
             transform_matrix=self.__image_to_surface_transform(
                 transform_matrix=transform_matrix,
             ),
+            custom_transformation=False,
         )
 
     def _map_from_surface_to_image(
@@ -173,6 +174,7 @@ class SurfaceLocation(abc.ABC):
             transform_matrix=self.__surface_to_image_transform(
                 transform_matrix=transform_matrix,
             ),
+            custom_transformation=True,
         )
 
     def _map_marker_from_image_to_surface(
@@ -268,8 +270,7 @@ class SurfaceLocation(abc.ABC):
 
     @staticmethod
     def __map_points(
-        points: np.ndarray,
-        transform_matrix: np.ndarray,
+        points: np.ndarray, transform_matrix: np.ndarray, custom_transformation=False
     ) -> np.ndarray:
 
         points = np.asarray(points)
@@ -288,8 +289,12 @@ class SurfaceLocation(abc.ABC):
         # Perspective transform
 
         shape = points.shape
-        points.shape = (-1, 1, 2)
-        points = _perspective_transform(points, transform_matrix)
+        if custom_transformation:
+            points.shape = (-1, 2)
+            points = _perspective_transform(points, transform_matrix)
+        else:
+            points.shape = (-1, 1, 2)
+            points = cv2.perspectiveTransform(points, transform_matrix)
         points.shape = shape
 
         return points
@@ -298,15 +303,63 @@ class SurfaceLocation(abc.ABC):
 ##### Helper functions
 
 
-def _perspective_transform(points, transform_matrix):
-    homogeneous_points = cv2.convertPointsToHomogeneous(points)
+def is_clockwise_triangle(points):
+    p1, p2, p3 = points
+    val = (float(p2[1] - p1[1]) * (p3[0] - p2[0])) - (
+        float(p2[0] - p1[0]) * (p3[1] - p2[1])
+    )
+    return val < 0
+
+
+def orientation_quadrupel(points, clockwise=True):
+    p0, p1, p2, p3 = points
+    return all(
+        (
+            is_clockwise_triangle((p0, p1, p2)) == clockwise,
+            is_clockwise_triangle((p1, p2, p3)) == clockwise,
+            is_clockwise_triangle((p2, p3, p0)) == clockwise,
+        )
+    )
+
+
+def project_points_pos_z(homogeneous_points, transform_matrix):
     res = []
     for p in homogeneous_points:
         projected_point = np.dot(transform_matrix, p[0])
-        projected_point[2] = abs(projected_point[2])  # flip points with negative z
+        if projected_point[2] < 0:
+            projected_point[2] = min(
+                abs(projected_point[2]),
+                np.linalg.norm([projected_point[0], projected_point[1]]) / 32,
+            )
         res.append(projected_point)
+    return res
 
-    return cv2.convertPointsFromHomogeneous(np.asarray(res))
+
+def _perspective_transform(points, transform_matrix):
+    homogeneous_points = cv2.convertPointsToHomogeneous(points)
+
+    proj_unflipped = project_points_pos_z(homogeneous_points, transform_matrix)
+    orientation_unflipped = orientation_quadrupel(proj_unflipped, clockwise=True)
+    points_unflipped = cv2.convertPointsFromHomogeneous(np.asarray(proj_unflipped))
+
+    proj_flipped = project_points_pos_z(-homogeneous_points, transform_matrix)
+    orientation_flipped = orientation_quadrupel(proj_flipped, clockwise=True)
+    points_flipped = cv2.convertPointsFromHomogeneous(np.asarray(proj_flipped))
+
+    if orientation_unflipped and not orientation_flipped:
+        return points_unflipped
+    if orientation_flipped and not orientation_unflipped:
+        return points_flipped
+    if orientation_unflipped and orientation_flipped:
+
+        def min_dist(points):
+            return min([np.linalg.norm(p) for p in points])
+
+        if min_dist(points_flipped) < min_dist(points_unflipped):
+            return points_flipped
+        else:
+            return points_unflipped
+    return points_unflipped
 
 
 def _find_homographies(points_A, points_B):

--- a/src/surface_tracker/surface.py
+++ b/src/surface_tracker/surface.py
@@ -252,7 +252,7 @@ def _bounding_quadrangle(vertices: np.ndarray):
     # See: https://github.com/pupil-labs/pupil/issues/1544
     vertices = np.asarray(vertices, dtype=np.float32)
 
-    hull_points = cv2.convexHull(vertices, clockwise=True)
+    hull_points = cv2.convexHull(vertices, clockwise=False)
 
     # The convex hull of a list of markers must have at least 4 corners, since a
     # single marker already has 4 corners. If the convex hull has more than 4

--- a/src/surface_tracker/surface.py
+++ b/src/surface_tracker/surface.py
@@ -252,7 +252,7 @@ def _bounding_quadrangle(vertices: np.ndarray):
     # See: https://github.com/pupil-labs/pupil/issues/1544
     vertices = np.asarray(vertices, dtype=np.float32)
 
-    hull_points = cv2.convexHull(vertices, clockwise=False)
+    hull_points = cv2.convexHull(vertices, clockwise=True)
 
     # The convex hull of a list of markers must have at least 4 corners, since a
     # single marker already has 4 corners. If the convex hull has more than 4


### PR DESCRIPTION
Hi!
the opencv `perspectiveTransform` function maps point back to euclidean space independent of the z-coordinate, which causes mirrored x and y coordinates for negative z. So this fix takes the absolute value of z for the conversion from homogeneous to euclidean coordinates. 
Feel free to merge or make changes!